### PR TITLE
Potential fix for code scanning alert 1-4

### DIFF
--- a/.github/workflows/pr-fixer.yml
+++ b/.github/workflows/pr-fixer.yml
@@ -23,34 +23,37 @@ jobs:
     steps:
       - name: Set Environment Variables
         env:
-          REPOSITORY: ${{ github.repository }}
           EVENT_NAME: ${{ github.event_name }}
-          ISSUE_PR_NUMBER: ${{ github.event.issue.number }}
-          ISSUE_COMMENT_BODY: ${{ github.event.comment.body }}
-          ISSUE_REACTION_PATH: /repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions
-          PR_REVIEW_COMMENT_PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_REVIEW_COMMENT_BODY: ${{ github.event.comment.body }}
-          PR_REVIEW_COMMENT_PATH: ${{ github.event.comment.path }}
-          PR_REVIEW_COMMENT_REACTION_PATH: /repos/${{ github.repository }}/pulls/comments/${{ github.event.comment.id }}/reactions
-          PR_REVIEW_NUMBER: ${{ github.event.pull_request.number }}
-          PR_REVIEW_BODY: ${{ github.event.review.body }}
-          PR_REVIEW_REACTION_PATH: /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews/${{ github.event.review.id }}/reactions
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_BODY_INPUT: ${{ github.event.comment.body }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          PR_NUMBER_INPUT: ${{ github.event.pull_request.number }}
+          REVIEW_BODY: ${{ github.event.review.body }}
+          REVIEW_ID: ${{ github.event.review.id }}
+          COMMENT_PATH: ${{ github.event.comment.path }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           echo "Event: $EVENT_NAME"
-          if [ "$EVENT_NAME" = "issue_comment" ]; then
-            echo "PR_NUMBER=$ISSUE_PR_NUMBER" >> "$GITHUB_ENV"
-            echo "COMMENT_BODY=$ISSUE_COMMENT_BODY" >> "$GITHUB_ENV"
-            echo "REACTION_PATH=$ISSUE_REACTION_PATH" >> "$GITHUB_ENV"
-          elif [ "$EVENT_NAME" = "pull_request_review_comment" ]; then
-            echo "PR_NUMBER=$PR_REVIEW_COMMENT_PR_NUMBER" >> "$GITHUB_ENV"
-            echo "COMMENT_BODY=$PR_REVIEW_COMMENT_BODY" >> "$GITHUB_ENV"
-            echo "TARGET_FILE=$PR_REVIEW_COMMENT_PATH" >> "$GITHUB_ENV"
-            echo "REACTION_PATH=$PR_REVIEW_COMMENT_REACTION_PATH" >> "$GITHUB_ENV"
-          elif [ "$EVENT_NAME" = "pull_request_review" ]; then
-            echo "PR_NUMBER=$PR_REVIEW_NUMBER" >> "$GITHUB_ENV"
-            echo "COMMENT_BODY=$PR_REVIEW_BODY" >> "$GITHUB_ENV"
+          if [ "$EVENT_NAME" == "issue_comment" ]; then
+            echo "PR_NUMBER=$ISSUE_NUMBER" >> $GITHUB_ENV
+            echo "COMMENT_BODY<<EOF" >> $GITHUB_ENV
+            echo "$COMMENT_BODY_INPUT" >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
+            echo "REACTION_PATH=/repos/$REPOSITORY/issues/comments/$COMMENT_ID/reactions" >> $GITHUB_ENV
+          elif [ "$EVENT_NAME" == "pull_request_review_comment" ]; then
+            echo "PR_NUMBER=$PR_NUMBER_INPUT" >> $GITHUB_ENV
+            echo "COMMENT_BODY<<EOF" >> $GITHUB_ENV
+            echo "$COMMENT_BODY_INPUT" >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
+            echo "TARGET_FILE=$COMMENT_PATH" >> $GITHUB_ENV
+            echo "REACTION_PATH=/repos/$REPOSITORY/pulls/comments/$COMMENT_ID/reactions" >> $GITHUB_ENV
+          elif [ "$EVENT_NAME" == "pull_request_review" ]; then
+            echo "PR_NUMBER=$PR_NUMBER_INPUT" >> $GITHUB_ENV
+            echo "COMMENT_BODY<<EOF" >> $GITHUB_ENV
+            echo "$REVIEW_BODY" >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
             # Reactions on reviews are different, we'll skip reaction for now or target the review
-            echo "REACTION_PATH=$PR_REVIEW_REACTION_PATH" >> "$GITHUB_ENV"
+            echo "REACTION_PATH=/repos/$REPOSITORY/pulls/$PR_NUMBER_INPUT/reviews/$REVIEW_ID/reactions" >> $GITHUB_ENV
           fi
 
       - name: Checkout Repository
@@ -62,7 +65,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr checkout ${{ env.PR_NUMBER }}
+          gh pr checkout $PR_NUMBER
 
       - name: Get PR Info
         id: pr_info
@@ -72,16 +75,10 @@ jobs:
           echo "Target File before check: $TARGET_FILE"
           if [ -z "$TARGET_FILE" ]; then
             # If no target file (issue comment or review summary), find the first .md file that was changed in this PR
-            PR_DATA=$(gh pr view ${{ env.PR_NUMBER }} --json files)
-            MD_FILE=$(echo "$PR_DATA" | jq -r '.files[] | select(.path | endswith(".md")) | .path' | head -n 1)
-
-            # Sanitize MD_FILE before using it in GITHUB_ENV to prevent environment injection
-            MD_FILE_CLEAN=$(printf '%s' "$MD_FILE" | tr -d '\n')
-            # Optionally trim leading/trailing whitespace
-            MD_FILE_CLEAN="${MD_FILE_CLEAN#"${MD_FILE_CLEAN%%[![:space:]]*}"}"
-            MD_FILE_CLEAN="${MD_FILE_CLEAN%"${MD_FILE_CLEAN##*[![:space:]]}"}"
+            PR_DATA=$(gh pr view $PR_NUMBER --json files)
+            MD_FILE=$(echo $PR_DATA | jq -r '.files[] | select(.path | endswith(".md")) | .path' | head -n 1)
             
-            if [ -z "$MD_FILE_CLEAN" ]; then
+            if [ -z "$MD_FILE" ]; then
               echo "No markdown file found in this PR."
               exit 0 # Exit gracefully if no MD file to update
             fi
@@ -130,5 +127,5 @@ jobs:
             --method POST \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            ${{ env.REACTION_PATH }} \
+            "$REACTION_PATH" \
             -f "content=rocket" || echo "Could not add reaction"


### PR DESCRIPTION
Potential fix for [https://github.com/coltonchrane/AutoNotes/security/code-scanning/3](https://github.com/coltonchrane/AutoNotes/security/code-scanning/3)

In general, to avoid code injection from untrusted GitHub event fields in `run:` steps, set them via the `env:` block of the step using expression syntax, and then reference them inside the script using the shell’s own environment-variable syntax (e.g., `$COMMENT_BODY`). Do not embed `${{ ... }}` directly in the shell script for untrusted values.

For this workflow, the minimal fix is to stop interpolating `github.event.*.body` (and other untrusted comment fields) directly into the shell script in the "Set Environment Variables" step. Instead, declare `PR_NUMBER`, `COMMENT_BODY`, `TARGET_FILE`, and `REACTION_PATH` in the step’s `env:` section using `${{ ... }}` expressions, and then have the shell script echo those values into `$GITHUB_ENV` using `$PR_NUMBER`, `$COMMENT_BODY`, etc. This preserves behavior (the same variables end up in the environment for later steps) while ensuring the shell never interprets GitHub expressions that contain user input.

Concretely, edit `.github/workflows/pr-fixer.yml` in the `Set Environment Variables` step:
- Add an `env:` mapping under the step with keys `ISSUE_PR_NUMBER`, `ISSUE_COMMENT_BODY`, `ISSUE_REACTION_PATH`, `PR_REVIEW_COMMENT_BODY`, `PR_REVIEW_COMMENT_PATH`, `PR_REVIEW_COMMENT_REACTION_PATH`, `PR_REVIEW_NUMBER`, `PR_REVIEW_BODY`, `PR_REVIEW_REACTION_PATH`, and `REPOSITORY`, each set using `${{ ... }}` to the existing event fields.
- Replace each `echo "PR_NUMBER=...${{ ... }}" >> $GITHUB_ENV` and similar with `echo "PR_NUMBER=$ISSUE_PR_NUMBER" >> $GITHUB_ENV`, `echo "COMMENT_BODY=$ISSUE_COMMENT_BODY" >> $GITHUB_ENV`, etc., using the appropriate env variable for each branch. This removes all `${{ ... }}` usages from the shell body, including the problematic `${{ github.event.review.body }}` on line 38.
- You do not need new imports or external dependencies, just YAML changes inside the shown step.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
